### PR TITLE
Update 28_prumyslove_komunikacni_systemy.md

### DIFF
--- a/28_prumyslove_komunikacni_systemy/28_prumyslove_komunikacni_systemy.md
+++ b/28_prumyslove_komunikacni_systemy/28_prumyslove_komunikacni_systemy.md
@@ -47,9 +47,9 @@ Komunikační systémy pro tato odvětví by měly být:
 
 Uvedená směs sběrnic je hodně různoroda a můžeme jí rozdělit do několika pomyslných skupin podle specifického použití. (moje neoficiální dělení)
 
-- **Průmyslové** (CAN, RS-232 a asi i Ethernet)
+- **Průmyslové** (CAN, RS-485, RS-422, (průmyslový) Ethernet, RS-232)
 
-  - pracují na vzdálenost desítky metrů
+  - pracují na vzdálenost desítek metrů
   - nejsou potřeba velké přenosové rychlosti
   - odolné proti rušení (kompromis na úkor přenosové rychlosti)
   - hardware je obvykle odolný na vysoké teploty, prach a elektromagnetické záření
@@ -71,9 +71,9 @@ Uvedená směs sběrnic je hodně různoroda a můžeme jí rozdělit do několi
 
 ## Používané systémy
 
-**USART**
+**UART/USART**
 
-Synchronní / asynchronní sériové rozhraní USART (Universal Synchronous / Asynchronous Receiver and Transmitter). Jde o zařízení pro sériovou komunikaci, které lze nastavit buď pro asynchronní režim (SCI – např. pro linky RS232 resp. RS485), anebo pro synchronní režim (běžně označovaný jako SPI).
+Univerzální synchronní / asynchronní sériové rozhraní USART (Universal Synchronous / Asynchronous Receiver and Transmitter). Jde o zařízení pro sériovou komunikaci, které lze nastavit buď pro asynchronní režim (SCI – např. pro linky RS-232 resp. RS-485), anebo pro synchronní režim (běžně označovaný jako SPI). USART se od UARTu liší možností synchroní komunikace.
 
 ### CAN
 


### PR DESCRIPTION
Uprava a doplnění. V průmyslu se spíše používá RS-485 než RS-232 když už jde fakt o průmysl a větší vzdálenosti. 
U toho USARTu doplněn UART, protože by je to mohlo zajímat. Některé MCU mají třeba jen UART periferní modul(y).

U toho ethernetu exisutje odnož průmyslový ethernet (https://en.wikipedia.org/wiki/Industrial_Ethernet), ale co jsem se kdy setkal, tak se používal normální ethernet jen s pořádným stíněním. Ale standardně se již v průmyslu používá, jen se používají kvalitnější komponenty s lepším stíněním než si člověk koupí domů.
